### PR TITLE
migrate to pnpm 11

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,4 +38,4 @@ jobs:
         env:
           NPM_TAG: ${{ steps.dist-tag.outputs.tag }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm publish --provenance --access public --no-git-checks --tag "$NPM_TAG"
+        run: npm publish --provenance --access public --tag "$NPM_TAG"

--- a/package.json
+++ b/package.json
@@ -71,17 +71,12 @@
     "vite-tsconfig-paths": "6.1.1",
     "vitest": "4.1.5"
   },
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.0.9",
   "engines": {
     "node": ">=24"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
-  },
   "volta": {
     "node": "24.15.0",
-    "pnpm": "10.33.4"
+    "pnpm": "11.0.9"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Summary
- Bump `packageManager` and `volta.pnpm` to `pnpm@11.0.9`
- Remove `pnpm.onlyBuiltDependencies` block from package.json (the field is removed in v11)
- Add `pnpm-workspace.yaml` with `allowBuilds: { esbuild: true }` (v11's replacement)
- Switch publish step from `pnpm publish --provenance` to `npm publish --provenance` because pnpm 11's native publish dropped the `--provenance` flag

## Notes
- Lockfile format unchanged (still v9.0)
- v11 changes several defaults (`minimumReleaseAge: 1440`, `strictDepBuilds: true`, `blockExoticSubdeps: true`); none affect this template's current behavior
- Node `>=24` already satisfies v11's Node 22+ floor

## Test plan
- [x] `pnpm check` passes locally on v11.0.9
- [x] `pnpm build` passes locally (attw + publint)
- [x] `pnpm test` passes locally
- [ ] CI green on Linux + Windows