### PR TITLE
bump node to 26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 24
+          - 26
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 24
+          - 26
         os-release:
           - blacksmith-4vcpu-ubuntu-2404
           - blacksmith-4vcpu-windows-2025

--- a/package.json
+++ b/package.json
@@ -73,10 +73,10 @@
   },
   "packageManager": "pnpm@11.0.9",
   "engines": {
-    "node": ">=24"
+    "node": ">=26"
   },
   "volta": {
-    "node": "24.15.0",
+    "node": "26.1.0",
     "pnpm": "11.0.9"
   }
 }


### PR DESCRIPTION
## Summary
- `engines.node`: `>=24` -> `>=26`
- `volta.node`: `24.15.0` -> `26.1.0`
- CI matrix node-version: `24` -> `26` (build.yml + test.yml)

tsdown's build target is derived from `engines.node`, so it auto-rolls to `node26.0.0`.

Branch protection contexts will need updating from `*node@24` to `*node@26` before merge.

## Test plan
- [x] pnpm check passes locally on Node 26.1.0
- [x] pnpm build passes locally (target: node26.0.0, attw + publint)
- [x] pnpm test passes locally
- [ ] CI green on Linux + Windows