### PR TITLE
use native pnpm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,4 +38,4 @@ jobs:
         env:
           NPM_TAG: ${{ steps.dist-tag.outputs.tag }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --provenance --access public --tag "$NPM_TAG"
+        run: pnpm publish --provenance --access public --no-git-checks --tag "$NPM_TAG"


### PR DESCRIPTION
## Summary
Revert the publish step to native `pnpm publish --provenance`. Per the v11 docs (https://pnpm.io/11.x/cli/publish), `--provenance` is supported on pnpm 11; it was just missing from `pnpm publish --help` output, which led to switching to `npm publish` in the v11 migration PR.

Verified with `pnpm publish --provenance --dry-run --no-git-checks` on 11.0.9 locally — flag parses and dry-run completes.

## Test plan
- [x] Dry-run publish accepts `--provenance` on pnpm 11.0.9
- [ ] Build/test CI green
- [ ] Verified provenance attestation appears on next real release