### PR TITLE
stabilize ci check names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: build on node@${{ matrix.node-version }}
+    name: build
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,6 @@ jobs:
     name: build
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
-    strategy:
-      matrix:
-        node-version:
-          - 26
-
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -23,7 +18,7 @@ jobs:
       - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: package.json
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    name: test on ${{ matrix.os-release }} node@${{ matrix.node-version }}
+    name: test on ${{ matrix.os-release }}
     runs-on: ${{ matrix.os-release }}
 
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
 
     strategy:
       matrix:
-        node-version:
-          - 26
         os-release:
           - blacksmith-4vcpu-ubuntu-2404
           - blacksmith-4vcpu-windows-2025
@@ -28,7 +26,7 @@ jobs:
       - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: package.json
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
Drop the node version (and matrix-derived suffix) from the `name:` field on CI jobs so the resulting GitHub status check names stay stable across Node bumps.

Before / after:
- `build on node@26` -> `build`
- `test on blacksmith-4vcpu-ubuntu-2404 node@26` -> `test on blacksmith-4vcpu-ubuntu-2404`
- `test on blacksmith-4vcpu-windows-2025 node@26` -> `test on blacksmith-4vcpu-windows-2025`

This means future Node major bumps no longer need a paired branch-protection update (the node@24 -> node@26 dance from the last bump won't recur).

Branch protection contexts will be PATCHed to the new names before merging.

## Test plan
- [x] Workflow yaml lints (oxfmt/oxlint don't touch yaml; verified manually)
- [ ] CI green under the new names
- [ ] Branch protection contexts updated