### PR TITLE
publish to npm via trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,5 +37,4 @@ jobs:
       - name: publish
         env:
           NPM_TAG: ${{ steps.dist-tag.outputs.tag }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm publish --provenance --access public --no-git-checks --tag "$NPM_TAG"


### PR DESCRIPTION
npm tokens are being restricted (account changes Aug 2026, direct publishing Jan 2027) and the existing ones are expiring. Publishing already goes through OIDC when a trusted publisher is configured, so the token env var is a dead fallback path.

Needs a trusted publisher on npmjs.com for this package before the next release: repository 2BAD/ts-lib-starter, workflow publish.yml, no environment.